### PR TITLE
Plonk_proof: do not use std::array but use array_init

### DIFF
--- a/kimchi/wasm/src/plonk_proof.rs
+++ b/kimchi/wasm/src/plonk_proof.rs
@@ -16,7 +16,6 @@ use ark_ff::One;
 use array_init::array_init;
 use kimchi::circuits::wires::COLUMNS;
 use kimchi::verifier::Context;
-use std::array;
 // use std::path::Path;
 use groupmap::GroupMap;
 use kimchi::proof::{
@@ -690,7 +689,7 @@ macro_rules! impl_proof {
                     rot_selector: None,
                     lookup_aggregation: None,
                     lookup_table: None,
-                    lookup_sorted: array::from_fn(|_| None),
+                    lookup_sorted: array_init(|_| None),
                     runtime_lookup_table: None,
                     runtime_lookup_table_selector: None,
                     xor_lookup_selector: None,


### PR DESCRIPTION
To avoid introducing a new import. `array_init` is used in the rest of the file. 