### PR TITLE
Bigint backend pt 8: Adapt conversion to latest kimchi types

### DIFF
--- a/crypto/bindings/conversion-verifier-index.ts
+++ b/crypto/bindings/conversion-verifier-index.ts
@@ -184,20 +184,29 @@ function verifierIndexConversionPerField(
   function lookupSelectorsToRust([
     ,
     lookup,
+    xor,
+    range_check,
+    ffmul,
   ]: LookupSelectors<PolyComm>): WasmLookupSelector {
     return new LookupSelector(
-      undefined,
+      MlOption.mapFrom(xor, core.polyCommToRust),
       MlOption.mapFrom(lookup, core.polyCommToRust),
-      undefined,
-      undefined
+      MlOption.mapFrom(range_check, core.polyCommToRust),
+      MlOption.mapFrom(ffmul, core.polyCommToRust)
     );
   }
   function lookupSelectorsFromRust(
     selector: WasmLookupSelector
   ): LookupSelectors<PolyComm> {
     let lookup = MlOption.mapTo(selector.lookup, core.polyCommFromRust);
+    let xor = MlOption.mapTo(selector.xor, core.polyCommFromRust);
+    let range_check = MlOption.mapTo(
+      selector.range_check,
+      core.polyCommFromRust
+    );
+    let ffmul = MlOption.mapTo(selector.ffmul, core.polyCommFromRust);
     selector.free();
-    return [0, lookup];
+    return [0, lookup, xor, range_check, ffmul];
   }
 
   function lookupInfoToRust([

--- a/crypto/bindings/kimchi-types.ts
+++ b/crypto/bindings/kimchi-types.ts
@@ -22,7 +22,6 @@ export {
   ProverCommitments,
   OpeningProof,
   PointEvaluations,
-  LookupEvaluations,
   ProofEvaluations,
   RecursionChallenge,
   ProverProof,
@@ -141,24 +140,37 @@ type PointEvaluations<Field> = [
   zeta: MlArray<Field>,
   zeta_omega: MlArray<Field>
 ];
-type LookupEvaluations<Field> = [
-  _: 0,
-  sorted: MlArray<PointEvaluations<Field>>,
-  aggreg: PointEvaluations<Field>,
-  table: PointEvaluations<Field>,
-  runtime: MlOption<PointEvaluations<Field>>
-];
+
 type nColumns = 15;
 type nPermutsMinus1 = 6;
+
 type ProofEvaluations<Field> = [
   _: 0,
   w: MlTupleN<PointEvaluations<Field>, nColumns>,
   z: PointEvaluations<Field>,
   s: MlTupleN<PointEvaluations<Field>, nPermutsMinus1>,
   coefficients: MlTupleN<PointEvaluations<Field>, nColumns>,
-  lookup: MlOption<LookupEvaluations<Field>>,
   generic_selector: PointEvaluations<Field>,
-  poseidon_selector: PointEvaluations<Field>
+  poseidon_selector: PointEvaluations<Field>,
+  complete_add_selector: PointEvaluations<Field>,
+  mul_selector: PointEvaluations<Field>,
+  emul_selector: PointEvaluations<Field>,
+  endomul_scalar_selector: PointEvaluations<Field>,
+  range_check0_selector: MlOption<PointEvaluations<Field>>,
+  range_check1_selector: MlOption<PointEvaluations<Field>>,
+  foreign_field_add_selector: MlOption<PointEvaluations<Field>>,
+  foreign_field_mul_selector: MlOption<PointEvaluations<Field>>,
+  xor_selector: MlOption<PointEvaluations<Field>>,
+  rot_selector: MlOption<PointEvaluations<Field>>,
+  lookup_aggregation: MlOption<PointEvaluations<Field>>,
+  lookup_table: MlOption<PointEvaluations<Field>>,
+  lookup_sorted: MlArray<MlOption<PointEvaluations<Field>>>,
+  runtime_lookup_table: MlOption<PointEvaluations<Field>>,
+  runtime_lookup_table_selector: MlOption<PointEvaluations<Field>>,
+  xor_lookup_selector: MlOption<PointEvaluations<Field>>,
+  lookup_gate_lookup_selector: MlOption<PointEvaluations<Field>>,
+  range_check_lookup_selector: MlOption<PointEvaluations<Field>>,
+  foreign_field_mul_lookup_selector: MlOption<PointEvaluations<Field>>
 ];
 type RecursionChallenge = [_: 0, chals: MlArray<Field>, comm: PolyComm];
 

--- a/crypto/bindings/lookup.ts
+++ b/crypto/bindings/lookup.ts
@@ -21,7 +21,13 @@ type LookupInfo = [
   max_joint_size: number,
   features: LookupFeatures
 ];
-type LookupSelectors<PolyComm> = [_: 0, lookup: MlOption<PolyComm>];
+type LookupSelectors<PolyComm> = [
+  _: 0,
+  lookup: MlOption<PolyComm>,
+  xor: MlOption<PolyComm>,
+  range_check: MlOption<PolyComm>,
+  ffmul: MlOption<PolyComm>
+];
 type Lookup<PolyComm> = [
   _: 0,
   joint_lookup_used: MlBool,


### PR DESCRIPTION
Incremental step on top of #144 

Adapts TS kimchi types to latest OCaml / Rust code and introduces a (no-op) conversion of point evaluations which we need in #127 when switching to a different snarky field representation