### PR TITLE
Foreign field backend

### DIFF
--- a/crypto/finite-field-examples.ts
+++ b/crypto/finite-field-examples.ts
@@ -10,7 +10,8 @@ let pSmall = 101n;
 let pBabybear = (1n << 31n) - 1n;
 let pGoldilocks = (1n << 64n) - (1n << 32n) + 1n;
 let p25519 = (1n << 255n) - 19n;
-let pSeqp256k1 = (1n << 256n) - (1n << 32n) - 0b1111010001n;
+let pSecp256k1 = (1n << 256n) - (1n << 32n) - 0b1111010001n;
+let pSecq256k1 = (1n << 256n) - 0x14551231950b75fc4402da1732fc9bebfn;
 let pBls12_381 =
   0x01ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001n;
 let qBls12_381 =
@@ -23,7 +24,8 @@ let exampleFields = {
   babybear: createField(pBabybear),
   goldilocks: createField(pGoldilocks),
   f25519: createField(p25519),
-  seqp256k1_base: createField(pSeqp256k1),
+  secp256k1: createField(pSecp256k1),
+  secq256k1: createField(pSecq256k1),
   bls12_381_base: createField(pBls12_381),
   bls12_381_scalar: createField(qBls12_381),
 };

--- a/crypto/finite-field-examples.ts
+++ b/crypto/finite-field-examples.ts
@@ -1,0 +1,27 @@
+/**
+ * This file contains some examples of finite fields, to be used for tests
+ */
+import { Fp, Fq, createField } from './finite_field.js';
+
+export { exampleFields };
+
+// some primes
+let pSmall = 101n;
+let pBabybear = (1n << 31n) - 1n;
+let pGoldilocks = (1n << 64n) - (1n << 32n) + 1n;
+let p25519 = (1n << 255n) - 19n;
+let pBls12_381 =
+  0x01ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001n;
+let qBls12_381 =
+  0x12ab655e9a2ca55660b44d1e5c37b00159aa76fed00000010a11800000000001n;
+
+let exampleFields = {
+  pastaFp: Fp,
+  pastaFq: Fq,
+  small: createField(pSmall),
+  babybear: createField(pBabybear),
+  goldilocks: createField(pGoldilocks),
+  f25519: createField(p25519),
+  bls12_381_fp: createField(pBls12_381),
+  bls12_381_fq: createField(qBls12_381),
+};

--- a/crypto/finite-field-examples.ts
+++ b/crypto/finite-field-examples.ts
@@ -16,8 +16,8 @@ let qBls12_381 =
   0x12ab655e9a2ca55660b44d1e5c37b00159aa76fed00000010a11800000000001n;
 
 let exampleFields = {
-  pastaFp: Fp,
-  pastaFq: Fq,
+  Fp,
+  Fq,
   small: createField(pSmall),
   babybear: createField(pBabybear),
   goldilocks: createField(pGoldilocks),

--- a/crypto/finite-field-examples.ts
+++ b/crypto/finite-field-examples.ts
@@ -10,6 +10,7 @@ let pSmall = 101n;
 let pBabybear = (1n << 31n) - 1n;
 let pGoldilocks = (1n << 64n) - (1n << 32n) + 1n;
 let p25519 = (1n << 255n) - 19n;
+let pSeqp256k1 = (1n << 256n) - (1n << 32n) - 0b1111010001n;
 let pBls12_381 =
   0x01ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001n;
 let qBls12_381 =
@@ -22,6 +23,7 @@ let exampleFields = {
   babybear: createField(pBabybear),
   goldilocks: createField(pGoldilocks),
   f25519: createField(p25519),
-  bls12_381_fp: createField(pBls12_381),
-  bls12_381_fq: createField(qBls12_381),
+  seqp256k1_base: createField(pSeqp256k1),
+  bls12_381_base: createField(pBls12_381),
+  bls12_381_scalar: createField(qBls12_381),
 };

--- a/crypto/finite-field.unit-test.ts
+++ b/crypto/finite-field.unit-test.ts
@@ -1,27 +1,11 @@
-import { Fp, Fq, createField } from './finite_field.js';
+import { Fp, Fq } from './finite_field.js';
 import assert from 'node:assert/strict';
 import { Random, test } from '../../lib/testing/property.js';
+import { exampleFields } from './finite-field-examples.js';
 
-// some more primes
-let pSmall = 101n;
-let pBabybear = (1n << 31n) - 1n;
-let pGoldilocks = (1n << 64n) - (1n << 32n) + 1n;
-let p25519 = (1n << 255n) - 19n;
-let pBls12_381 =
-  0x01ae3a4617c510eac63b05c06ca1493b1a22d9f300f5138f1ef3622fba094800170b5d44300000008508c00000000001n;
-let qBls12_381 =
-  0x12ab655e9a2ca55660b44d1e5c37b00159aa76fed00000010a11800000000001n;
+let fields = Object.values(exampleFields);
 
-let fields = [
-  pSmall,
-  pBabybear,
-  pGoldilocks,
-  p25519,
-  pBls12_381,
-  qBls12_381,
-].map((p) => createField(p));
-
-for (let F of [Fp, Fq, ...fields]) {
+for (let F of fields) {
   // t is computed correctly from p = 2^M * t + 1
   assert(F.t * (1n << F.M) + 1n === F.modulus, 't, M are computed correctly');
 

--- a/crypto/finite_field.ts
+++ b/crypto/finite_field.ts
@@ -1,7 +1,7 @@
 import { bytesToBigInt } from './bigint-helpers.js';
 import { randomBytes } from './random.js';
 
-export { Fp, Fq, FiniteField, p, q, mod, inverse };
+export { createField, Fp, Fq, FiniteField, p, q, mod, inverse };
 
 // CONSTANTS
 
@@ -65,13 +65,13 @@ function inverse(a: bigint, p: bigint) {
   return mod(x, p);
 }
 
-function sqrt(n: bigint, p: bigint, Q: bigint, c: bigint) {
+function sqrt(n: bigint, p: bigint, Q: bigint, c: bigint, M: bigint) {
   // https://en.wikipedia.org/wiki/Tonelli-Shanks_algorithm#The_algorithm
   // variable naming is the same as in that link ^
   // Q is what we call `t` elsewhere - the odd factor in p - 1
   // c is a known primitive root of unity
+  // M is the twoadicity = exponent of 2 in factorization of p - 1
   if (n === 0n) return 0n;
-  let M = 32n;
   let t = power(n, (Q - 1n) >> 1n, p); // n^(Q - 1)/2
   let R = mod(t * n, p); // n^((Q - 1)/2 + 1) = n^((Q + 1)/2)
   t = mod(t * R, p); // n^((Q - 1)/2 + (Q + 1)/2) = n^Q
@@ -99,11 +99,11 @@ function isSquare(x: bigint, p: bigint) {
   return sqrt1 === 1n;
 }
 
-function randomField(p: bigint) {
+function randomField(p: bigint, sizeInBytes: number, hiBitMask: number) {
   // strategy: find random 255-bit bigints and use the first that's smaller than p
   while (true) {
-    let bytes = randomBytes(32);
-    bytes[31] &= 0x7f; // zero highest bit, so we get 255 random bits
+    let bytes = randomBytes(sizeInBytes);
+    bytes[sizeInBytes - 1] &= hiBitMask; // zero highest bit, so we get 255 random bits
     let x = bytesToBigInt(bytes);
     if (x < p) return x;
   }
@@ -112,15 +112,34 @@ function randomField(p: bigint) {
 // SPECIALIZATIONS TO FP, FQ
 // these should be mostly trivial
 
-const Fp = createField(p, pMinusOneOddFactor, twoadicRootFp);
-const Fq = createField(q, qMinusOneOddFactor, twoadicRootFq);
+const Fp = createField(p, {
+  oddFactor: pMinusOneOddFactor,
+  twoadicRoot: twoadicRootFp,
+  twoadicity: 32n,
+});
+const Fq = createField(q, {
+  oddFactor: qMinusOneOddFactor,
+  twoadicRoot: twoadicRootFq,
+  twoadicity: 32n,
+});
 type FiniteField = ReturnType<typeof createField>;
 
-function createField(p: bigint, t: bigint, twoadicRoot: bigint) {
+function createField(
+  p: bigint,
+  constants?: { oddFactor: bigint; twoadicRoot: bigint; twoadicity: bigint }
+) {
+  let { oddFactor, twoadicRoot, twoadicity } =
+    constants ?? computeFieldConstants(p);
+  let sizeInBits = p.toString(2).length;
+  let sizeInBytes = Math.ceil(sizeInBits / 8);
+  let sizeHighestByte = sizeInBits - 8 * (sizeInBytes - 1);
+  let hiBitMask = (1 << sizeHighestByte) - 1;
+
   return {
     modulus: p,
-    sizeInBits: 255,
-    t,
+    sizeInBits,
+    t: oddFactor,
+    M: twoadicity,
     twoadicRoot,
 
     add(x: bigint, y: bigint) {
@@ -150,7 +169,7 @@ function createField(p: bigint, t: bigint, twoadicRoot: bigint) {
       return isSquare(x, p);
     },
     sqrt(x: bigint) {
-      return sqrt(x, p, t, twoadicRoot);
+      return sqrt(x, p, oddFactor, twoadicRoot, twoadicity);
     },
     power(x: bigint, n: bigint) {
       return power(x, n, p);
@@ -170,7 +189,7 @@ function createField(p: bigint, t: bigint, twoadicRoot: bigint) {
       return !(x & 1n);
     },
     random() {
-      return randomField(p);
+      return randomField(p, sizeInBytes, hiBitMask);
     },
     fromNumber(x: number) {
       return mod(BigInt(x), p);
@@ -196,4 +215,27 @@ function createField(p: bigint, t: bigint, twoadicRoot: bigint) {
       return BigInt('0b' + binary.reverse().join(''));
     },
   };
+}
+
+/**
+ * Compute constants to instantiate a finite field just from the modulus
+ */
+function computeFieldConstants(p: bigint) {
+  // figure out the factorization p - 1 = 2^M * t
+  let oddFactor = p - 1n;
+  let twoadicity = 0n;
+  while ((oddFactor & 1n) === 0n) {
+    oddFactor >>= 1n;
+    twoadicity++;
+  }
+
+  // find z = non-square
+  // start with 2 and increment until we find one
+  let z = 2n;
+  while (isSquare(z, p)) z++;
+
+  // primitive root of unity is z^t
+  let twoadicRoot = power(z, oddFactor, p);
+
+  return { oddFactor, twoadicRoot, twoadicity };
 }


### PR DESCRIPTION
This PR generalizes the bigint finite field code to work for all fields.
This enables foreign field tests in https://github.com/o1-labs/o1js-bindings/pull/203

We also add a file with a range of concrete finite fields that can be used for testing and in examples.