### PR TITLE
fix: memoize initO1 and export an equivlent initO1 from node-backend

### DIFF
--- a/js/node/node-backend.js
+++ b/js/node/node-backend.js
@@ -13,6 +13,10 @@ const wasm = wasm_;
 
 export { wasm, withThreadPool };
 
+export async function initO1() {
+  // TODO: what needs to be done here?
+}
+
 let workersReadyResolve;
 let workersReady;
 

--- a/js/web/web-backend.js
+++ b/js/web/web-backend.js
@@ -23,7 +23,13 @@ let workerPromise;
  */
 let numWorkers = undefined;
 
+let isInitialized = false;
+
 async function initO1() {
+  if (isInitialized) {
+    return;
+  }
+  isInitialized = true;
   const memory = allocateWasmMemoryForUserAgent(navigator.userAgent);
   await init(undefined, memory);
 


### PR DESCRIPTION
This is a first step in fixing: https://github.com/o1-labs/o1js/issues/1575

1. We need to move `await initO1()` top-level await out of the `import o1js` path.
2. This means we'll move that code to be lazily evaluated throughout the `o1js` library
3. To achieve that, the `node-backend.js` needs to export an equivalent `initO1` function. For now, I left is as a no-op but need guidance.

Note: I find it strange that these bindings are in a separate repo. It really makes these kinds of changes difficult. 