### PR TITLE
Add Detailed Error Handling for Invalid Struct Type Usage

### DIFF
--- a/lib/provable-generic.ts
+++ b/lib/provable-generic.ts
@@ -178,13 +178,6 @@ function createDerivers<Field>(): {
 
       if (isProvable(typeObj)) return typeObj.check(obj);
 
-      if (typeof typeObj === 'function') {
-        throw new Error(
-          `provable: invalid type detected. Functions are not supported as types. ` +
-            `Ensure you are passing an instance of a supported type or an anonymous object.\n`
-        );
-      }
-
       if (display(typeObj) === 'Struct') {
         throw new Error(
           `provable: cannot run check() on 'Struct' type. ` +
@@ -198,6 +191,13 @@ function createDerivers<Field>(): {
             `class MyStruct extends Struct({\n` +
             `  fieldA: MySpecificStruct, // Use the specific struct type\n` +
             `}) {}\n`
+        );
+      }
+
+      if (typeof typeObj === 'function') {
+        throw new Error(
+          `provable: invalid type detected. Functions are not supported as types. ` +
+            `Ensure you are passing an instance of a supported type or an anonymous object.\n`
         );
       }
 

--- a/lib/provable-generic.ts
+++ b/lib/provable-generic.ts
@@ -173,6 +173,21 @@ function createDerivers<Field>(): {
       if (!complexTypes.has(typeof typeObj))
         throw Error(`provable: unsupported type "${typeObj}"`);
 
+      if (display(typeObj) === 'Struct')
+        throw Error(
+          `provable: cannot run check() on 'Struct' type. ` +
+            `Instead of using 'Struct' directly, extend 'Struct' to create a specific type.\n\n` +
+            `Example:\n` +
+            `// Incorrect Usage:\n` +
+            `class MyStruct extends Struct({\n` +
+            `  fieldA: Struct, // This is incorrect\n` +
+            `}) {}\n\n` +
+            `// Correct Usage:\n` +
+            `class MyStruct extends Struct({\n` +
+            `  fieldA: MySpecificStruct, // Use the specific struct type\n` +
+            `}) {}\n`
+        );
+
       if (Array.isArray(typeObj))
         return typeObj.forEach((t, i) => check(t, obj[i]));
 

--- a/lib/provable-generic.ts
+++ b/lib/provable-generic.ts
@@ -173,6 +173,11 @@ function createDerivers<Field>(): {
       if (!complexTypes.has(typeof typeObj))
         throw Error(`provable: unsupported type "${typeObj}"`);
 
+      if (Array.isArray(typeObj))
+        return typeObj.forEach((t, i) => check(t, obj[i]));
+
+      if (isProvable(typeObj)) return typeObj.check(obj);
+
       if (display(typeObj) === 'Struct')
         throw Error(
           `provable: cannot run check() on 'Struct' type. ` +
@@ -187,11 +192,6 @@ function createDerivers<Field>(): {
             `  fieldA: MySpecificStruct, // Use the specific struct type\n` +
             `}) {}\n`
         );
-
-      if (Array.isArray(typeObj))
-        return typeObj.forEach((t, i) => check(t, obj[i]));
-
-      if (isProvable(typeObj)) return typeObj.check(obj);
 
       return Object.keys(typeObj).forEach((k) => check(typeObj[k], obj[k]));
     }

--- a/lib/provable-generic.ts
+++ b/lib/provable-generic.ts
@@ -178,8 +178,15 @@ function createDerivers<Field>(): {
 
       if (isProvable(typeObj)) return typeObj.check(obj);
 
-      if (display(typeObj) === 'Struct')
-        throw Error(
+      if (typeof typeObj === 'function') {
+        throw new Error(
+          `provable: invalid type detected. Functions are not supported as types. ` +
+            `Ensure you are passing an instance of a supported type or an anonymous object.\n`
+        );
+      }
+
+      if (display(typeObj) === 'Struct') {
+        throw new Error(
           `provable: cannot run check() on 'Struct' type. ` +
             `Instead of using 'Struct' directly, extend 'Struct' to create a specific type.\n\n` +
             `Example:\n` +
@@ -192,7 +199,9 @@ function createDerivers<Field>(): {
             `  fieldA: MySpecificStruct, // Use the specific struct type\n` +
             `}) {}\n`
         );
+      }
 
+      // Only recurse into the object if it's an object and not a function
       return Object.keys(typeObj).forEach((k) => check(typeObj[k], obj[k]));
     }
 


### PR DESCRIPTION
## Summary
This PR addresses an issue with the check() method in circuit classes extending Struct. 

## Changes
- Add a runtime check for `check` which checks if we are running on a `Struct` and throw an error if so

## Test Case

```ts
import { Struct, Bool, Field } from 'o1js';

class WrappedStruct extends Struct({
  wrappedA: Struct,
}) {}

class WrappedBool extends Struct({
  wrappedB: Bool,
}) {}

class WrappedStructGood extends Struct({
  wrappedA: WrappedBool,
}) {}

let notBool = new Bool(false);
notBool.value = new Field(2n).value; // set to a non-bool

let wrappedBool = new WrappedBool({
  wrappedB: notBool,
});
let wrappedWrappedBool = new WrappedStruct({
  wrappedA: wrappedBool,
});

let wrappedWrappedBoolGood = new WrappedStructGood({
  wrappedA: wrappedBool,
});

WrappedBool.check(wrappedBool); // should throw error correctly from check (invalid Bool)
WrappedStructGood.check(wrappedWrappedBoolGood); // should throw error correctly from check (invalid Bool)
WrappedStruct.check(wrappedWrappedBool); // should error here with thrown error (cannot use Struct here)
```