### PR TITLE
Update instructions on building mina-transaction/gen/

### DIFF
--- a/mina-transaction/gen/README.md
+++ b/mina-transaction/gen/README.md
@@ -17,4 +17,4 @@ let deriver obj =
 
 To consume a custom deriver and add custom behavior, `transaction-leaves-bigint.ts` and `transaction-leaves.ts` must be changed.
 
-To regenerate them, check out the [mina repository](https://github.com/MinaProtocol/mina) and run `make snarkyjs` (heads up: there are a lot of things to install and set up if you build mina the first time).
+To regenerate them, run `npm run build:update-bindings` from o1js.


### PR DESCRIPTION
Mina doesn't seem to have `make snarkyjs` anymore, but these bindings are regenerated by `npm run build:update-bindings` 

Here's the call to dune:
https://github.com/o1-labs/o1js-bindings/blob/ff3588199eaf8f423c4474862f049bf1d8ed4c77/scripts/build-o1js-node-artifacts.sh#L39