### PR TITLE
Support Secp256r1

### DIFF
--- a/crypto/elliptic-curve-examples.ts
+++ b/crypto/elliptic-curve-examples.ts
@@ -15,6 +15,18 @@ const secp256k1Params: CurveParams = {
   },
 };
 
+const secp256r1Params: CurveParams = {
+  name: 'secp256r1',
+  modulus: exampleFields.secp256r1.modulus,
+  order: 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551n,
+  a: 0xffffffff00000001000000000000000000000000fffffffffffffffffffffffcn,
+  b: 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604bn,
+  generator: {
+    x: 0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296n,
+    y: 0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5n,
+  },
+};
+
 const pallasParams: CurveParams = {
   name: 'Pallas',
   modulus: Pallas.modulus,
@@ -39,6 +51,7 @@ const vestaParams: CurveParams = {
 
 const CurveParams = {
   Secp256k1: secp256k1Params,
+  Secp256r1: secp256r1Params,
   Pallas: pallasParams,
   Vesta: vestaParams,
 };

--- a/crypto/elliptic-curve.ts
+++ b/crypto/elliptic-curve.ts
@@ -402,7 +402,7 @@ function projectiveOnCurve(
   a: bigint
 ) {
   // substitution x -> x/z^2 and y -> y/z^3 gives
-  // the equation y^2 = x^3 + a*z^4 + b*z^6
+  // the equation y^2 = x^3 + a*x*z^4 + b*z^6
   // (note: we allow a restricted set of x,y for z==0; this seems fine)
   let x3 = mod(mod(x * x, p) * x, p);
   let y2 = mod(y * y, p);

--- a/crypto/elliptic-curve.ts
+++ b/crypto/elliptic-curve.ts
@@ -575,7 +575,7 @@ function affineDouble(
   // m = (3*x^2 + a) / 2y
   let d = inverse(2n * y, p);
   if (d === undefined) throw Error('impossible');
-  let m = mod(3n * x * x * d + a, p);
+  let m = mod((3n * x * x + a) * d, p);
   // x2 = m^2 - 2x
   let x2 = mod(m * m - 2n * x, p);
   // y2 = m*(x - x2) - y

--- a/crypto/elliptic-curve.unit-test.ts
+++ b/crypto/elliptic-curve.unit-test.ts
@@ -1,11 +1,18 @@
-import { Pallas, Vesta } from './elliptic-curve.js';
+import {
+  createCurveAffine,
+  createCurveProjective,
+  Pallas,
+  Vesta,
+} from './elliptic-curve.js';
 import { Fp, Fq } from './finite-field.js';
 import assert from 'node:assert/strict';
 import { test, Random } from '../../lib/testing/property.js';
+import { CurveParams } from './elliptic-curve-examples.js';
 
 for (let [G, Field, Scalar] of [
   [Pallas, Fp, Fq] as const,
   [Vesta, Fq, Fp] as const,
+  curveWithFields(CurveParams.Secp256k1),
 ]) {
   // endomorphism constants
   assert.equal(Field.power(G.endoBase, 3n), 1n, 'cube root in base field');
@@ -124,4 +131,20 @@ for (let [G, Field, Scalar] of [
       );
     }
   );
+}
+
+// helper
+
+function curveWithFields(params: CurveParams) {
+  // this computes endo constants if they aren't there from the beginning
+  let Affine = createCurveAffine(params);
+
+  let Projective = createCurveProjective({
+    ...params,
+    endoBase: Affine.Endo.base,
+    endoScalar: Affine.Endo.scalar,
+  });
+
+  // return Curve, Field and Scalar
+  return [Projective, Affine.Field, Affine.Scalar] as const;
 }

--- a/crypto/elliptic-curve.unit-test.ts
+++ b/crypto/elliptic-curve.unit-test.ts
@@ -13,10 +13,17 @@ for (let [G, Field, Scalar] of [
   [Pallas, Fp, Fq] as const,
   [Vesta, Fq, Fp] as const,
   curveWithFields(CurveParams.Secp256k1),
+  curveWithFields(CurveParams.Secp256r1),
 ]) {
   // endomorphism constants
-  assert.equal(Field.power(G.endoBase, 3n), 1n, 'cube root in base field');
-  assert.equal(Scalar.power(G.endoScalar, 3n), 1n, 'cube root in scalar field');
+  if (G.hasEndomorphism) {
+    assert.equal(Field.power(G.endoBase, 3n), 1n, 'cube root in base field');
+    assert.equal(
+      Scalar.power(G.endoScalar, 3n),
+      1n,
+      'cube root in scalar field'
+    );
+  }
 
   let randomScalar = Random(Scalar.random);
   let randomField = Random(Field.random);
@@ -41,17 +48,20 @@ for (let [G, Field, Scalar] of [
     (X, Y, Z, x, y, f) => {
       // check on curve
       assert(G.isOnCurve(X) && G.isOnCurve(Y) && G.isOnCurve(Z), 'on curve');
-      // can't be on curve because b=5 is a non-square
-      assert(!Field.isSquare(G.b));
-      assert(
-        !G.isOnCurve({ x: 0n, y, z: 1n }),
-        'x=0 => y^2 = b is not on curve'
-      );
-      // can't be on curve because the implied equation is f^6 = f^6 + b
-      assert(
-        !G.isOnCurve({ x: Field.power(f, 2n), y: Field.power(f, 3n), z: 1n }),
-        'x^3 = y^2 is not on curve'
-      );
+
+      if (G.a === 0n) {
+        // can't be on curve because b=5 is a non-square
+        assert(!Field.isSquare(G.b));
+        assert(
+          !G.isOnCurve({ x: 0n, y, z: 1n }),
+          'x=0 => y^2 = b is not on curve'
+        );
+        // can't be on curve because the implied equation is f^6 = f^6 + b
+        assert(
+          !G.isOnCurve({ x: Field.power(f, 2n), y: Field.power(f, 3n), z: 1n }),
+          'x^3 = y^2 is not on curve'
+        );
+      }
 
       // equal
       assert(G.equal(X, X), 'equal');
@@ -109,10 +119,12 @@ for (let [G, Field, Scalar] of [
       );
 
       // endomorphism
-      assert(
-        G.equal(G.endomorphism(X), G.scale(X, G.endoScalar)),
-        'efficient endomorphism'
-      );
+      if (G.hasEndomorphism) {
+        assert(
+          G.equal(G.endomorphism(X), G.scale(X, G.endoScalar)),
+          'efficient endomorphism'
+        );
+      }
 
       // subgroup
       assert(G.isInSubgroup(X), 'subgroup check');
@@ -126,7 +138,8 @@ for (let [G, Field, Scalar] of [
       let { x: xa, y: ya } = affineX;
       assert(
         G.equal(X, G.zero) ||
-          Field.square(ya) === Field.add(Field.power(xa, 3n), G.b),
+          Field.square(ya) ===
+            Field.add(Field.add(Field.power(xa, 3n), Field.mul(G.a, xa)), G.b),
         'affine on curve (or zero)'
       );
     }
@@ -139,11 +152,14 @@ function curveWithFields(params: CurveParams) {
   // this computes endo constants if they aren't there from the beginning
   let Affine = createCurveAffine(params);
 
-  let Projective = createCurveProjective({
-    ...params,
-    endoBase: Affine.Endo.base,
-    endoScalar: Affine.Endo.scalar,
-  });
+  if (Affine.hasEndomorphism) {
+    params = {
+      ...params,
+      endoBase: Affine.Endo.base,
+      endoScalar: Affine.Endo.scalar,
+    };
+  }
+  let Projective = createCurveProjective(params);
 
   // return Curve, Field and Scalar
   return [Projective, Affine.Field, Affine.Scalar] as const;

--- a/crypto/finite-field-examples.ts
+++ b/crypto/finite-field-examples.ts
@@ -26,6 +26,10 @@ let exampleFields = {
   f25519: createField(p25519),
   secp256k1: createField(pSecp256k1),
   secq256k1: createField(pSecq256k1),
+  secp256r1:
+    createField(
+      0xffffffff00000001000000000000000000000000ffffffffffffffffffffffffn
+    ),
   bls12_381_base: createField(pBls12_381),
   bls12_381_scalar: createField(qBls12_381),
 };


### PR DESCRIPTION
companion of https://github.com/o1-labs/o1js/pull/1885

* support general curve parameter `a` in most elliptic curve methods
* change many EC methods to take the additional `a` parameter
* support curve parameter `a = -3` in projective curve doubling
  * this is the parameter used by secp256r1
  * note: there is a more efficient algorithm for a=-3 than for general `a`. thanks to the other changes here, it would now be _very_ simple to add the general `a` case as well, but for testing we would need a concrete curve with general `a`, and I'm skipping the work of finding one since I'm not interested in general curves here
* unit-test the new curve (and also its base field)