### PR TITLE
Fix Lagrange bases caching on the web

### DIFF
--- a/js/web/web-backend.js
+++ b/js/web/web-backend.js
@@ -135,6 +135,8 @@ function overrideBindings(plonk_wasm, worker) {
   let spec = workerSpec(plonk_wasm);
   for (let key in spec) {
     plonk_wasm[key] = (...args) => {
+      if (spec[key].disabled)
+        throw Error(`Wasm method '${key}' is disabled on the web.`);
       let u32_ptr = wasm.create_zero_u32_ptr();
       worker.postMessage({
         type: 'run',

--- a/js/web/worker-spec.js
+++ b/js/web/worker-spec.js
@@ -105,11 +105,20 @@ function workerSpec(wasm) {
       res: wasm.WasmFqSrs,
     },
     caml_fp_srs_get_lagrange_basis: {
+      disabled: true,
       args: [wasm.WasmFpSrs, undefined /* number */],
+      // TODO: returning a UintXArray does not work:
+      // the worker wrapper excepts the return value to be a number
+      // that can be stored in a single u32.
+      // A UintXArray is coerced into a 0 pointer, which doesn't trigger `wait_until_non_zero()`,
+      // which means the main worker just keeps spinning waiting for a response.
+      // A proper solution would be to wrap the return value in a pointer!
       res: undefined /* UintXArray */,
     },
     caml_fq_srs_get_lagrange_basis: {
+      disabled: true,
       args: [wasm.WasmFqSrs, undefined /* number */],
+      // TODO: returning a UintXArray does not work, see above
       res: undefined /* UintXArray */,
     },
     caml_fp_srs_b_poly_commitment: {


### PR DESCRIPTION
companion of https://github.com/o1-labs/o1js/pull/1906

this fixes a case where `compile()` got stuck on the web version and kept spinning without error.

diagnosis:
* when the recursive verifier circuit needed access to fp lagrange bases, it ended up in `lagrangeCommitment()` in `srs.ts`
* there, in the case of a cache miss, we attempted to call `getLagrangeBasis()` to get the entire lagrange basis and store it in the cache
* however, in the browser, there is an additional layer behind methods using concurrency, like `caml_fq_srs_get_lagrange_basis` which `getLagrangeBasis()` aliases to. this additional layer (see `web-backend.js` > `overrideBindings()`) was not able to handle the Uint32Array return value of `caml_fq_srs_get_lagrange_basis()`. instead, that return value was interpreted in a way that caused the method to _never_ return (even though the lagrange basis had been successfully created!)

the minimal fix is twofold:
  1. in the web worker layer, throw an error when calling one of the methods that would never return. 
  2. in the SRS caching layer, only attempt to return the full LB if we even have a writable cache. otherwise, call a different method that will store the LB internally but not attempt to return it.

The fix circumvents the problem in the most typical case, where we don't have a writable cache in the browser. In the case where we do have a writable cache, the error message and comments added here will make it very obvious what the problem is.

The full solution (which I don't have time for) is outlined in code comments