### PR TITLE
Run shellcheck

### DIFF
--- a/scripts/build-o1js-node-artifacts.sh
+++ b/scripts/build-o1js-node-artifacts.sh
@@ -2,38 +2,38 @@
 
 set -e
 
-MINA_PATH="src/mina"
-DUNE_PATH="src/bindings/ocaml/jsoo_exports"
-BUILD_PATH="_build/default/$DUNE_PATH"
-KIMCHI_BINDINGS="$MINA_PATH/src/lib/crypto/kimchi_bindings"
+MINA_PATH=src/mina
+DUNE_PATH=src/bindings/ocaml/jsoo_exports
+BUILD_PATH=_build/default/"${DUNE_PATH}"
+KIMCHI_BINDINGS="${MINA_PATH}"/src/lib/crypto/kimchi_bindings
 
 [ -d node_modules ] || npm i
 
 export DUNE_USE_DEFAULT_LINKER="y"
 
-if [ -f "$BUILD_PATH/o1js_node.bc.js" ]; then
+if [ -f "${BUILD_PATH}"/o1js_node.bc.js ]; then
   echo "found o1js_node.bc.js"
-  if [ -f "$BUILD_PATH/o1js_node.bc.map" ]; then
+  if [ -f "${BUILD_PATH}"/o1js_node.bc.map ]; then
     echo "found o1js_node.bc.map, saving at a tmp location because dune will delete it"
-    cp "$BUILD_PATH/o1js_node.bc.map" _build/o1js_node.bc.map ;
+    cp "${BUILD_PATH}"/o1js_node.bc.map _build/o1js_node.bc.map ;
   else
     echo "did not find o1js_node.bc.map, deleting o1js_node.bc.js to force calling jsoo again"
-    rm -f "$BUILD_PATH/o1js_node.bc.js"
+    rm -f "${BUILD_PATH}"/o1js_node.bc.js
   fi
 fi
 
 # Copy mina config files, that is necessary for o1js to build
-dune b "$MINA_PATH/src/config.mlh" && \
-cp "$MINA_PATH/src/config.mlh" "src" \
-&& cp -r "$MINA_PATH/src/config" "src/config" || exit 1
+dune b "${MINA_PATH}"/src/config.mlh && \
+cp "${MINA_PATH}"/src/config.mlh "src" \
+&& cp -r "${MINA_PATH}"/src/config "src/config" || exit 1
 
-dune b $KIMCHI_BINDINGS/js/node_js \
-&& dune b $DUNE_PATH/o1js_node.bc.js || exit 1
+dune b "${KIMCHI_BINDINGS}"/js/node_js \
+&& dune b "${DUNE_PATH}"/o1js_node.bc.js || exit 1
 
 # update if new source map was built
-if [ -f "$BUILD_PATH/o1js_node.bc.map" ]; then
+if [ -f "${BUILD_PATH}"/o1js_node.bc.map ]; then
   echo "new source map created";
-  cp "$BUILD_PATH/o1js_node.bc.map" "_build/o1js_node.bc.map";
+  cp "${BUILD_PATH}"/o1js_node.bc.map _build/o1js_node.bc.map;
 fi
 
 dune b src/bindings/mina-transaction/gen/v1/js-layout.ts \
@@ -47,30 +47,29 @@ rm -rf "src/config" \
 && rm "src/config.mlh" || exit 1
 
 BINDINGS_PATH=src/bindings/compiled/_node_bindings/
-mkdir -p "$BINDINGS_PATH"
-chmod -R 777 "$BINDINGS_PATH"
-cp _build/default/$KIMCHI_BINDINGS/js/node_js/plonk_wasm* "$BINDINGS_PATH"
-mv -f $BINDINGS_PATH/plonk_wasm.js $BINDINGS_PATH/plonk_wasm.cjs
-mv -f $BINDINGS_PATH/plonk_wasm.d.ts $BINDINGS_PATH/plonk_wasm.d.cts
-cp $BUILD_PATH/o1js_node*.js "$BINDINGS_PATH"
-cp src/bindings/compiled/node_bindings/o1js_node.bc.d.cts $BINDINGS_PATH/
-cp "_build/o1js_node.bc.map" "$BINDINGS_PATH"/o1js_node.bc.map
-mv -f $BINDINGS_PATH/o1js_node.bc.js $BINDINGS_PATH/o1js_node.bc.cjs
-sed -i 's/plonk_wasm.js/plonk_wasm.cjs/' $BINDINGS_PATH/o1js_node.bc.cjs
+mkdir -p "${BINDINGS_PATH}"
+chmod -R 777 "${BINDINGS_PATH}"
+cp _build/default/"${KIMCHI_BINDINGS}"/js/node_js/plonk_wasm* "${BINDINGS_PATH}"
+mv -f "${BINDINGS_PATH}"/plonk_wasm.js "${BINDINGS_PATH}"/plonk_wasm.cjs
+mv -f "${BINDINGS_PATH}"/plonk_wasm.d.ts "${BINDINGS_PATH}"/plonk_wasm.d.cts
+cp "${BUILD_PATH}"/o1js_node*.js "${BINDINGS_PATH}"
+cp src/bindings/compiled/node_bindings/o1js_node.bc.d.cts "${BINDINGS_PATH}"/
+cp "_build/o1js_node.bc.map" "${BINDINGS_PATH}"/o1js_node.bc.map
+mv -f "${BINDINGS_PATH}"/o1js_node.bc.js "${BINDINGS_PATH}"/o1js_node.bc.cjs
+sed -i 's/plonk_wasm.js/plonk_wasm.cjs/' "${BINDINGS_PATH}"/o1js_node.bc.cjs
 
 # cleanup tmp source map
-cp _build/o1js_node.bc.map $BUILD_PATH/o1js_node.bc.map
+cp _build/o1js_node.bc.map "${BUILD_PATH}"/o1js_node.bc.map
 rm -f _build/o1js_node.bc.map
 
 # better error messages
 # TODO: find a less hacky way to make adjustments to jsoo compiler output
 # `s` is the jsoo representation of the error message string, and `s.c` is the actual JS string
-sed -i 's/function failwith(s){throw \[0,Failure,s\]/function failwith(s){throw globalThis.Error(s.c)/' "$BINDINGS_PATH"/o1js_node.bc.cjs
-sed -i 's/function invalid_arg(s){throw \[0,Invalid_argument,s\]/function invalid_arg(s){throw globalThis.Error(s.c)/' "$BINDINGS_PATH"/o1js_node.bc.cjs
-sed -i 's/return \[0,Exn,t\]/return globalThis.Error(t.c)/' "$BINDINGS_PATH"/o1js_node.bc.cjs
+sed -i 's/function failwith(s){throw \[0,Failure,s\]/function failwith(s){throw globalThis.Error(s.c)/' "${BINDINGS_PATH}"/o1js_node.bc.cjs
+sed -i 's/function invalid_arg(s){throw \[0,Invalid_argument,s\]/function invalid_arg(s){throw globalThis.Error(s.c)/' "${BINDINGS_PATH}"/o1js_node.bc.cjs
+sed -i 's/return \[0,Exn,t\]/return globalThis.Error(t.c)/' "${BINDINGS_PATH}"/o1js_node.bc.cjs
 # TODO: this doesn't cover all cases, maybe should rewrite to_exn instead
-sed -i 's/function raise(t){throw caml_call1(to_exn$0,t)}/function raise(t){throw Error(t?.[1]?.c ?? "Unknown error thrown by raise")}/' "$BINDINGS_PATH"/o1js_node.bc.cjs
+sed -i 's/function raise(t){throw caml_call1(to_exn$0,t)}/function raise(t){throw Error(t?.[1]?.c ?? "Unknown error thrown by raise")}/' "${BINDINGS_PATH}"/o1js_node.bc.cjs
 
-chmod 777 "$BINDINGS_PATH"/*
-node "src/build/fix-wasm-bindings-node.js" "$BINDINGS_PATH/plonk_wasm.cjs"
-
+chmod 777 "${BINDINGS_PATH}"/*
+node "src/build/fix-wasm-bindings-node.js" "${BINDINGS_PATH}"/plonk_wasm.cjs

--- a/scripts/build-o1js-node.sh
+++ b/scripts/build-o1js-node.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-$(dirname "$0")/build-o1js-node-artifacts.sh
+"$(dirname "$0")"/build-o1js-node-artifacts.sh
 
 npm run dev

--- a/scripts/build-o1js-web.sh
+++ b/scripts/build-o1js-web.sh
@@ -8,18 +8,18 @@ BUILD_PATH="_build/default/$DUNE_PATH"
 KIMCHI_BINDINGS="$MINA_PATH/src/lib/crypto/kimchi_bindings"
 WEB_BINDINGS="src/bindings/compiled/web_bindings"
 
-dune b $DUNE_PATH/o1js_web.bc.js
-cp _build/default/$KIMCHI_BINDINGS/js/web/plonk_wasm* $WEB_BINDINGS/
-cp $BUILD_PATH/o1js_web*.js $WEB_BINDINGS/
+dune b "${DUNE_PATH}"/o1js_web.bc.js
+cp _build/default/"${KIMCHI_BINDINGS}"/js/web/plonk_wasm* "${WEB_BINDINGS}"/
+cp "${BUILD_PATH}"/o1js_web*.js "${WEB_BINDINGS}"/
 
 # better error messages
 # `s` is the jsoo representation of the error message string, and `s.c` is the actual JS string
-sed -i 's/function failwith(s){throw \[0,Failure,s\]/function failwith(s){throw globalThis.Error(s.c)/' $WEB_BINDINGS/o1js_web.bc.js
-sed -i 's/function invalid_arg(s){throw \[0,Invalid_argument,s\]/function invalid_arg(s){throw globalThis.Error(s.c)/' $WEB_BINDINGS/o1js_web.bc.js
-sed -i 's/return \[0,Exn,t\]/return globalThis.Error(t.c)/' $WEB_BINDINGS/o1js_web.bc.js
-sed -i 's/function raise(t){throw caml_call1(to_exn$0,t)}/function raise(t){throw Error(t?.[1]?.c ?? "some error")}/' $WEB_BINDINGS/o1js_web.bc.js
+sed -i 's/function failwith(s){throw \[0,Failure,s\]/function failwith(s){throw globalThis.Error(s.c)/' "${WEB_BINDINGS}"/o1js_web.bc.js
+sed -i 's/function invalid_arg(s){throw \[0,Invalid_argument,s\]/function invalid_arg(s){throw globalThis.Error(s.c)/' "${WEB_BINDINGS}"/o1js_web.bc.js
+sed -i 's/return \[0,Exn,t\]/return globalThis.Error(t.c)/' "${WEB_BINDINGS}"/o1js_web.bc.js
+sed -i 's/function raise(t){throw caml_call1(to_exn$0,t)}/function raise(t){throw Error(t?.[1]?.c ?? "some error")}/' "${WEB_BINDINGS}"/o1js_web.bc.js
 
-pushd $WEB_BINDINGS
+pushd "${WEB_BINDINGS}"
   wasm-opt --detect-features --enable-mutable-globals -O4 plonk_wasm_bg.wasm -o plonk_wasm_bg.wasm.opt
   mv plonk_wasm_bg.wasm.opt plonk_wasm_bg.wasm
 popd

--- a/scripts/check-commit.sh
+++ b/scripts/check-commit.sh
@@ -4,7 +4,7 @@ set -e
 
 MINA_PATH="src/mina"
 
-BUILT=$(cat src/bindings/MINA_COMMIT | sed 's/.* //')
+BUILT=$(sed 's/.* //' src/bindings/"${MINA_COMMIT}")
 
 pushd "${MINA_PATH}"
   MINA_COMMIT=$(git rev-parse HEAD)

--- a/scripts/check-commit.sh
+++ b/scripts/check-commit.sh
@@ -6,12 +6,12 @@ MINA_PATH="src/mina"
 
 BUILT=$(cat src/bindings/MINA_COMMIT | sed 's/.* //')
 
-pushd "$MINA_PATH"
+pushd "${MINA_PATH}"
   MINA_COMMIT=$(git rev-parse HEAD)
 popd
 
-if [ "$BUILT" != "$MINA_COMMIT" ]
+if [ "${BUILT}" != "${MINA_COMMIT}" ]
 then
-  echo mina is on $MINA_COMMIT but bindings were built for $BUILT
+  echo mina is on "${MINA_COMMIT}" but bindings were built for "${BUILT}"
   exit 1
 fi

--- a/scripts/prepare-dune-build.sh
+++ b/scripts/prepare-dune-build.sh
@@ -7,6 +7,6 @@ set -e
 MINA_PATH="src/mina"
 
 # Copy mina config files, that is necessary for o1js to build
-dune b "$MINA_PATH/src/config.mlh" && \
-cp "$MINA_PATH/src/config.mlh" "src" && \
-cp -r "$MINA_PATH/src/config" "src/config"
+dune b "${MINA_PATH}"/src/config.mlh && \
+cp "${MINA_PATH}"/src/config.mlh src && \
+cp -r "${MINA_PATH}"/src/config src/config

--- a/scripts/update-o1js-bindings.sh
+++ b/scripts/update-o1js-bindings.sh
@@ -12,20 +12,20 @@ WEB_BINDINGS="src/bindings/compiled/web_bindings"
 
 # 1. node build
 
-$DIR_PATH/build-o1js-node-artifacts.sh
-cp src/bindings/compiled/_node_bindings/plonk_wasm.d.cts $NODE_BINDINGS/plonk_wasm.d.cts
+"${DIR_PATH}"/build-o1js-node-artifacts.sh
+cp src/bindings/compiled/_node_bindings/plonk_wasm.d.cts "${NODE_BINDINGS}"/plonk_wasm.d.cts
 node src/build/copy-to-dist.js
 
-chmod -R 777 "$NODE_BINDINGS"
+chmod -R 777 "${NODE_BINDINGS}"
 
 BINDINGS_PATH=dist/node/bindings/compiled/_node_bindings
-cp "$BINDINGS_PATH"/o1js_node.bc.cjs "$NODE_BINDINGS"/o1js_node.bc.cjs
-cp "$BINDINGS_PATH"/o1js_node.bc.map "$NODE_BINDINGS"/o1js_node.bc.map
-cp "$BINDINGS_PATH"/plonk_wasm* "$NODE_BINDINGS"/
+cp "${BINDINGS_PATH}"/o1js_node.bc.cjs "${NODE_BINDINGS}"/o1js_node.bc.cjs
+cp "${BINDINGS_PATH}"/o1js_node.bc.map "${NODE_BINDINGS}"/o1js_node.bc.map
+cp "${BINDINGS_PATH}"/plonk_wasm* "${NODE_BINDINGS}"/
 
-sed -i 's/plonk_wasm.js/plonk_wasm.cjs/' "$NODE_BINDINGS"/o1js_node.bc.cjs
+sed -i 's/plonk_wasm.js/plonk_wasm.cjs/' "${NODE_BINDINGS}"/o1js_node.bc.cjs
 
-if [ -z $JUST_BINDINGS ]
+if [ -z "${JUST_BINDINGS}" ]
 then
   npm run build
 fi
@@ -34,55 +34,55 @@ fi
 
 # Normally these variables are not defined
 # But the nix build uses them
-if [ -z $PREBUILT_KIMCHI_BINDINGS_JS_WEB ] || [ -z $PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS ]
+if [ -z "${PREBUILT_KIMCHI_BINDINGS_JS_WEB}" ] || [ -z "${PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS}" ]
 then
   cp "$BUILD_PATH/o1js_node.bc.map" "_build/o1js_node.bc.map"
-  dune b $DUNE_PATH/o1js_web.bc.js
+  dune b "${DUNE_PATH}"/o1js_web.bc.js
   cp "_build/o1js_node.bc.map" "$BUILD_PATH/o1js_node.bc.map"
 
-  cp _build/default/$KIMCHI_BINDINGS/js/web/plonk_wasm* $WEB_BINDINGS/
-  cp $BUILD_PATH/o1js_web*.js $WEB_BINDINGS/
-  chmod -R 666 "$WEB_BINDINGS"/*
+  cp _build/default/"${KIMCHI_BINDINGS}"/js/web/plonk_wasm* "${WEB_BINDINGS}"/
+  cp "${BUILD_PATH}"/o1js_web*.js "${WEB_BINDINGS}"/
+  chmod -R 666 "${WEB_BINDINGS}"/*
 else
-  mkdir -p $WEB_BINDINGS
-  cp $PREBUILT_KIMCHI_BINDINGS_JS_WEB/*.js \
-     $PREBUILT_KIMCHI_BINDINGS_JS_WEB/*.ts \
-     $PREBUILT_KIMCHI_BINDINGS_JS_WEB/*.wasm \
-     $WEB_BINDINGS
-  mkdir -p $NODE_BINDINGS
-  cp $PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS/*.js \
-     $PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS/*.ts \
-     $PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS/*.wasm \
-     $NODE_BINDINGS
-  rm $NODE_BINDINGS/plonk_wasm.js \
-     $NODE_BINDINGS/plonk_wasm.d.ts
-  dune b $DUNE_PATH/o1js_web.bc.js
-  cp $BUILD_PATH/o1js_web*.js $WEB_BINDINGS/
+  mkdir -p "${WEB_BINDINGS}"
+  cp "${PREBUILT_KIMCHI_BINDINGS_JS_WEB}"/*.js \
+     "${PREBUILT_KIMCHI_BINDINGS_JS_WEB}"/*.ts \
+     "${PREBUILT_KIMCHI_BINDINGS_JS_WEB}"/*.wasm \
+     """${WEB_BINDINGS}"
+  mkdir -p "${NODE_BINDINGS}"
+  cp "${PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS}"/*.js \
+     "${PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS}"/*.ts \
+     "${PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS}"/*.wasm \
+     "${NODE_BINDINGS}"
+  rm "${NODE_BINDINGS}"/plonk_wasm.js \
+     "${NODE_BINDINGS}"/plonk_wasm.d.ts
+  dune b "${DUNE_PATH}"/o1js_web.bc.js
+  cp "${BUILD_PATH}"/o1js_web*.js "${WEB_BINDINGS}"/
 fi
 
 # better error messages
 # `s` is the jsoo representation of the error message string, and `s.c` is the actual JS string
-sed -i 's/function failwith(s){throw \[0,Failure,s\]/function failwith(s){throw globalThis.Error(s.c)/' $WEB_BINDINGS/o1js_web.bc.js
-sed -i 's/function invalid_arg(s){throw \[0,Invalid_argument,s\]/function invalid_arg(s){throw globalThis.Error(s.c)/' $WEB_BINDINGS/o1js_web.bc.js
-sed -i 's/return \[0,Exn,t\]/return globalThis.Error(t.c)/' $WEB_BINDINGS/o1js_web.bc.js
-sed -i 's/function raise(t){throw caml_call1(to_exn$0,t)}/function raise(t){throw Error(t?.[1]?.c ?? "Unknown error thrown by raise")}/' $WEB_BINDINGS/o1js_web.bc.js
+sed -i 's/function failwith(s){throw \[0,Failure,s\]/function failwith(s){throw globalThis.Error(s.c)/' "${WEB_BINDINGS}"/o1js_web.bc.js
+sed -i 's/function invalid_arg(s){throw \[0,Invalid_argument,s\]/function invalid_arg(s){throw globalThis.Error(s.c)/' "${WEB_BINDINGS}"/o1js_web.bc.js
+sed -i 's/return \[0,Exn,t\]/return globalThis.Error(t.c)/' "${WEB_BINDINGS}"/o1js_web.bc.js
+sed -i 's/function raise(t){throw caml_call1(to_exn$0,t)}/function raise(t){throw Error(t?.[1]?.c ?? "Unknown error thrown by raise")}/' "${WEB_BINDINGS}"/o1js_web.bc.js
 
 # optimize wasm / minify JS (we don't do this with jsoo to not break the error message fix above)
-pushd $WEB_BINDINGS
+pushd "${WEB_BINDINGS}"
   wasm-opt --detect-features --enable-mutable-globals -O4 plonk_wasm_bg.wasm -o plonk_wasm_bg.wasm.opt
   mv plonk_wasm_bg.wasm.opt plonk_wasm_bg.wasm
   npx esbuild --minify --log-level=error o1js_web.bc.js > o1js_web.bc.min.js
   mv o1js_web.bc.min.js o1js_web.bc.js
 popd
 
-if [ -z $JUST_BINDINGS ]
+if [ -z "${JUST_BINDINGS}" ]
 then
   npm run build:web
 fi
 
 # 3. update MINA_COMMIT file in o1js
 
-if [ -z $SKIP_MINA_COMMIT ]
+if [ -z "${SKIP_MINA_COMMIT}" ]
 then
 MINA_COMMIT=$(git -C src/mina rev-parse HEAD)
 echo "The mina commit used to generate the backends for node and web is" "$MINA_COMMIT" \

--- a/scripts/update-wasm-and-types.sh
+++ b/scripts/update-wasm-and-types.sh
@@ -13,15 +13,15 @@ NODE_BINDINGS="src/bindings/compiled/node_bindings"
 export DUNE_USE_DEFAULT_LINKER="y"
 
 # change to mina directory
-dune b $KIMCHI_BINDINGS/js/node_js
+dune b "${KIMCHI_BINDINGS}"/js/node_js
 
-chmod 777 "$_NODE_BINDINGS"/*
+chmod 777 "${_NODE_BINDINGS}"/*
 
-cp _build/default/$KIMCHI_BINDINGS/js/node_js/plonk_wasm* "$_NODE_BINDINGS"/
-mv -f $_NODE_BINDINGS/plonk_wasm.js $_NODE_BINDINGS/plonk_wasm.cjs
-mv -f $_NODE_BINDINGS/plonk_wasm.d.ts $_NODE_BINDINGS/plonk_wasm.d.cts
+cp _build/default/"${KIMCHI_BINDINGS}"/js/node_js/plonk_wasm* "$_NODE_BINDINGS"/
+mv -f "${_NODE_BINDINGS}"/plonk_wasm.js "${_NODE_BINDINGS}"/plonk_wasm.cjs
+mv -f "${_NODE_BINDINGS}"/plonk_wasm.d.ts "${_NODE_BINDINGS}"/plonk_wasm.d.cts
 
-chmod 777 "$_NODE_BINDINGS"/*
-node "src/build/fix-wasm-bindings-node.js" "$_NODE_BINDINGS/plonk_wasm.cjs"
+chmod 777 "${_NODE_BINDINGS}"/*
+node src/build/fix-wasm-bindings-node.js "${_NODE_BINDINGS}"/plonk_wasm.cjs
 
-cp $_NODE_BINDINGS/plonk_wasm.d.cts $NODE_BINDINGS/
+cp "${_NODE_BINDINGS}"/plonk_wasm.d.cts "${NODE_BINDINGS}"/


### PR DESCRIPTION
Mostly because my text editor run shellcheck directly, and I'm going right now into these scripts.
There are still some errors:
```
In src/bindings/scripts/update-o1js-bindings.sh line 68:
sed -i 's/function raise(t){throw caml_call1(to_exn$0,t)}/function raise(t){throw Error(t?.[1]?.c ?? "Unknown error thrown by raise")}/' "${WEB_BINDINGS}"/o1js_web.bc.js
       ^-- SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.
```